### PR TITLE
Support more versions of datamart-profiler

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         "scikit-learn",
         "networkx",
         "notebook",
-        "datamart_profiler==0.8.1",
+        "datamart-profiler>=0.8",
         "pandas"
     ]
 )


### PR DESCRIPTION
It's hard to install packages when all of them depend on very specific versions of dependencies.

For example, [AlphaD3M requires `datamart-profiler==0.9`](https://gitlab.com/ViDA-NYU/d3m/alphad3m/-/blob/1839260ac24fcfcff5ec03739737882d142bd7cb/requirements.txt#L5) and cannot be installed together with this.